### PR TITLE
ci: add OG image renderer

### DIFF
--- a/.github/workflows/og-image.yml
+++ b/.github/workflows/og-image.yml
@@ -1,0 +1,29 @@
+name: Build OG images
+on:
+  push:
+    paths:
+      - 'assets/og-banner.svg'
+      - 'assets/cognocarta-scroll.svg'
+  workflow_dispatch: {}
+jobs:
+  render:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+      - run: npm install -g svgexport
+      - run: |
+          mkdir -p assets
+          if [ -f assets/og-banner.svg ]; then svgexport assets/og-banner.svg assets/og-banner.png 1200:630; fi
+          if [ -f assets/cognocarta-scroll.svg ]; then svgexport assets/cognocarta-scroll.svg assets/cognocarta-scroll.png 1200:630; fi
+      - name: Commit rendered PNG
+        run: |
+          if [ -n "" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add assets/*.png
+            git commit -m "ci(og): render SVG → PNG"
+            git push
+          fi

--- a/assets/og-banner.svg
+++ b/assets/og-banner.svg
@@ -1,0 +1,10 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='1200' height='630' viewBox='0 0 1200 630'>
+  <defs><radialGradient id='g' cx='50%' cy='50%' r='70%'><stop offset='0%' stop-color='#0b0b0f'/><stop offset='100%' stop-color='#000'/></radialGradient></defs>
+  <rect width='100%' height='100%' fill='url(#g)'/>
+  <g fill='#fff' opacity='0.85'>
+    <circle cx='150' cy='80' r='2'/><circle cx='300' cy='140' r='1.5'/><circle cx='900' cy='120' r='2.2'/><circle cx='700' cy='300' r='1.7'/>
+    <circle cx='1100' cy='500' r='2'/><circle cx='200' cy='520' r='1.4'/><circle cx='500' cy='430' r='1.6'/>
+  </g>
+  <text x='600' y='290' text-anchor='middle' font-family='Inter,Segoe UI,Arial' font-weight='700' font-size='72' fill='#fff'>GIBindex</text>
+  <text x='600' y='360' text-anchor='middle' font-family='Inter,Segoe UI,Arial' font-size='28' fill='#d0d0d0'>Lexicon for Inter-AI Communications</text>
+</svg>


### PR DESCRIPTION
Adds SVG→PNG renderer for social previews. After merge, upload assets/*.png via Settings → Social preview.